### PR TITLE
Use master GNOME runtime for the Flatpak manifest

### DIFF
--- a/com.github.johnfactotum.QuickLookup.json
+++ b/com.github.johnfactotum.QuickLookup.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.github.johnfactotum.QuickLookup",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.36",
+    "runtime-version": "master",
     "sdk": "org.gnome.Sdk",
     "command": "quick-lookup",
     "finish-args": [


### PR DESCRIPTION
Helps when building in GNOME Builder.

Unfortunately, text input still seems to be broken upstream, so you can't look up anything currently.